### PR TITLE
2 of the Node definitions in sd-wan wouldn't import so I updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,4 @@ This project was written and is maintained by the following individuals:
 
 * Hank Preston <hank.preston@gmail.com>
 * Joe Clarke <jclarke@marcuscom.com>
+* Paul Van Lierop <pevanlierop@gmail.com>

--- a/node-definitions/cisco/sd-wan/iosxe-sdwan.yaml
+++ b/node-definitions/cisco/sd-wan/iosxe-sdwan.yaml
@@ -77,3 +77,4 @@ ui:
   label: XE-SDWAN
   label_prefix: xe-sdwan-
   visible: true
+schema_version: 0.0.1

--- a/node-definitions/cisco/sd-wan/iosxe-sdwan.yaml
+++ b/node-definitions/cisco/sd-wan/iosxe-sdwan.yaml
@@ -77,4 +77,3 @@ ui:
   label: XE-SDWAN
   label_prefix: xe-sdwan-
   visible: true
-schema_version: 0.1

--- a/node-definitions/cisco/sd-wan/viptela-edge.yaml
+++ b/node-definitions/cisco/sd-wan/viptela-edge.yaml
@@ -76,4 +76,3 @@ ui:
   label: vEdge
   label_prefix: vedge-
   visible: true
-schema_version: 0.1

--- a/node-definitions/cisco/sd-wan/viptela-edge.yaml
+++ b/node-definitions/cisco/sd-wan/viptela-edge.yaml
@@ -76,3 +76,4 @@ ui:
   label: vEdge
   label_prefix: vedge-
   visible: true
+schema_version: 0.0.1


### PR DESCRIPTION
In the node definitions listed there was a `schema_version: 0.1` line at the EOF that was preventing CML from importing those as node definitions.  I'm not sure of the intended use but removing the line allows them to be imported successfully.