### PR TITLE
Update opnsense

### DIFF
--- a/node-definitions/opnsense/README.md
+++ b/node-definitions/opnsense/README.md
@@ -2,6 +2,4 @@
 
 Here you will find collections of OPNsense node definitions.
 
-**NOTE:** There seems to be an odd ACPI issue that prevents OPNsense from booting within CML when using a single CPU. Setting the CPU count to two resolved the issue.
-
 Default credentials are `root:opnsense`

--- a/node-definitions/opnsense/opnsense.yaml
+++ b/node-definitions/opnsense/opnsense.yaml
@@ -26,8 +26,9 @@ sim:
     driver: asav
     disk_driver: virtio
     ram: 2048
-    cpus: 2
+    cpus: 1
     nic_driver: virtio
+    cpu_limit: 100
 boot:
   timeout: 300
   completed:
@@ -38,11 +39,13 @@ inherited:
     cpus: true
     data_volume: false
     boot_disk_size: false
+    cpu_limit: true
   node:
     ram: true
     cpus: true
     data_volume: false
     boot_disk_size: false
+    cpu_limit: true
 configuration:
   generator:
     driver: null

--- a/virl-base-images/opnsense/README.md
+++ b/virl-base-images/opnsense/README.md
@@ -6,7 +6,7 @@ Once you have the image archive, unarchive it, convert the image to qcow2, and t
 
 Here is an example of how I did it:
 
-`bzip2 -d OPNsense-20.7-OpenSSL-nano-amd64.img`
+`bzip2 -d OPNsense-20.7-OpenSSL-nano-amd64.img.bz2`
 
 `qemu-img convert -f raw -O qcow2 OPNsense-20.7-OpenSSL-nano-amd64.img OPNsense-20.7-OpenSSL-nano-amd64.qcow2`
 


### PR DESCRIPTION
Updating yaml and README for CML 2.1. Also added bz2 extension on to the image README for easy cut+paste follow through of the instructions - it downloads from OPNsense with an extension of .img.bz2. Also worth noting that assigning 2 vcpus as a workaround for ACPI related boot issues is no longer needed so I changed it back to 1 to conserve server resources. CML 2.1 added the CPU Limits field and I configured as it's required by the definition in 2.1. 