### PR TITLE
Fix for sim.video.memory

### DIFF
--- a/node-definitions/juniper/qfx/jnpr-vqfx-pfe.yaml
+++ b/node-definitions/juniper/qfx/jnpr-vqfx-pfe.yaml
@@ -47,7 +47,7 @@ sim:
     ram: 2048
     cpu_limit: 100
     video:
-      memory: 1
+      memory: 16
 boot:
   timeout: 600
   completed:

--- a/node-definitions/juniper/qfx/jnpr-vqfx-pfe.yaml
+++ b/node-definitions/juniper/qfx/jnpr-vqfx-pfe.yaml
@@ -47,7 +47,7 @@ sim:
     ram: 2048
     cpu_limit: 100
     video:
-      memory: 1024
+      memory: 1
 boot:
   timeout: 600
   completed:

--- a/validation_schemas/node_definition.json
+++ b/validation_schemas/node_definition.json
@@ -483,7 +483,7 @@
                         "memory": {
                             "type": "integer",
                             "minimum": 1,
-                            "maximum": 2048,
+                            "maximum": 128,
                             "description": "Video Memory."
                         }
                     }


### PR DESCRIPTION
ND validation schema:
- change the range for `sim.video.memory` back to 1-128 MiB, should be enough.

jnpr-vqfx-pfe: 
- fix `sim.video.memory` value: This attribute is in MiB, so 1 MiB should be enough, but rather set to 16 as default,  just like for the other NDs which support VNC