### PR TITLE
change cat8000v nd max number of interfaces

### DIFF
--- a/node-definitions/cisco/cat8000v/cat8000v.yaml
+++ b/node-definitions/cisco/cat8000v/cat8000v.yaml
@@ -66,12 +66,6 @@ device:
       - GigabitEthernet24
       - GigabitEthernet25
       - GigabitEthernet26
-      - GigabitEthernet27
-      - GigabitEthernet28
-      - GigabitEthernet29
-      - GigabitEthernet30
-      - GigabitEthernet31
-      - GigabitEthernet32
     serial_ports: 2
 general:
   description: Catalyst 8000V Edge Software


### PR DESCRIPTION
Cisco Catalyst 8000V supports the Virtio vNIC type on the KVM implementation. KVM supports a
maximum of 26 vNICs. 