### PR TITLE
Document Node Definition that supports a vEOS day0 config

### DIFF
--- a/node-definitions/arista/veos/README.md
+++ b/node-definitions/arista/veos/README.md
@@ -10,8 +10,37 @@ A valid vEOS image can be downloaded the through Arista support portal. https://
 
 ### Notes
 
-This node definition uses recommended values for vEOS instances. However, lowering the DRAM to 1.5GB should theoritically work but YMMV. 
+This node definition uses recommended values for vEOS instances. However, lowering the DRAM to 1.5GB should theoritically work but YMMV.
 
+> [!IMPORTANT]
+> For day0 configuration (`veos_usr.dat` file on ISO drive labeled `ARISTA_CONFIG_DRIVE`) to work, you must boot the QCOW2 image from Arista, allow it to install the full `vEOS-lab.swi` image, touch the file `/mnt/flash/kickstart-config`, then shut the system down.  This image will become your base QCOW2 image to load into CML.
 
+* First boot the raw image:
 
+```
+...
+Data in /mnt/flash/vEOS-lab.swi differs from previous boot image on /mnt/flash.
+Saving new boot image to /mnt/flash...
+...
+localhost login: admin
+localhost>en
+localhost#bash
+
+Arista Networks EOS shell
+
+[admin@localhost ~]$ sudo cat /mnt/flash/.CloudInitLogs
+Execute sudo mount /dev/disk/by-label/ARISTA_CONFIG_DRIVE /tmp/userdata8c9kqk8e
+Output:
+Erorr : b'mount: /tmp/userdata8c9kqk8e: WARNING: source write-protected, mounted read-only.\n'
+Caught exception [Errno 2] No such file or directory: '/mnt/flash/kickstart-config'. Ignoring KVM CloudInit
+Execute sudo umount /tmp/userdata8c9kqk8e
+Output:
+Erorr : b''
+CloudInit done !
+
+[admin@localhost ~]$ sudo touch /mnt/flash/kickstart-config
+[admin@localhost ~]$ sudo shutdown -h now
+```
+
+* [Collapse/Flatten](https://blog.programster.org/qemu-img-cheatsheet#collapse-all-images) image as normal and copy to a new image definition.
 

--- a/node-definitions/arista/veos/vEOS.yaml
+++ b/node-definitions/arista/veos/vEOS.yaml
@@ -1,24 +1,28 @@
 id: vEOS
 general:
-  description: Arista vEOS
+  description: |-
+    Arista vEOS.
+
+    Username: admin Password: <no-password> / admin
   nature: switch
   read_only: false
 device:
   interfaces:
     has_loopback_zero: true
     physical:
-      - eth0
-      - eth2
-      - eth3
-      - eth4
-      - eth5
-      - eth6
-      - eth7
-      - eth9
-      - eth10
-      - eth11
-      - eth12
-      - eth13
+      - Ma1
+      - Et1
+      - Et2
+      - Et3
+      - Et4
+      - Et5
+      - Et6
+      - Et7
+      - Et8
+      - Et9
+      - Et10
+      - Et11
+      - Et12
     serial_ports: 1
     default_count: 5
     loopback:
@@ -45,6 +49,7 @@ sim:
     nic_driver: virtio
 boot:
   timeout: 180
+  uses_regex: false
 inherited:
   image:
     ram: true
@@ -61,4 +66,33 @@ inherited:
 configuration:
   generator:
     driver: null
+  provisioning:
+    volume_name: ARISTA_CONFIG_DRIVE
+    media_type: iso
+    files:
+      - name: veos_usr.dat
+        editable: true
+        content: |-
+          %EOS-STARTUP-CONFIG-START%
+          !
+          no aaa root
+          !
+          username admin privilege 15 role network-admin secret 0 admin
+          !
+          switchport default mode access
+          !
+          logging console debugging
+          !
+          hostname inserthostname-here
+          !
+          interface Ethernet1
+          !
+          interface Management1
+          !
+          ip routing
+          !
+          end
+          %EOS-STARTUP-CONFIG-END%
+          %CLOUDHA-CONFIG-START%
+          %CLOUDHA-CONFIG-END%
 schema_version: 0.0.1


### PR DESCRIPTION
* Correct ordering of interfaces.  Management1 is the first interface, followed by Ethernet1 and the rest.
* Document how to create a base image after SWI completes
* Tests good with vEOS 4.33.2F 64-bit