### PR TITLE
Add libnsl-dev to the aaa-tacacs-exploration lab topologies

### DIFF
--- a/lab-topologies/aaa-tacacs-exploration/Snack_Minute_AAA_TACACS_Exploration.yaml
+++ b/lab-topologies/aaa-tacacs-exploration/Snack_Minute_AAA_TACACS_Exploration.yaml
@@ -223,6 +223,7 @@ nodes:
             - flex
             - bison
             - libwrap0-dev
+            - libnsl-dev
 
           write_files:
             # Create the tac_plus configuration file

--- a/lab-topologies/aaa-tacacs-exploration/aaa-exploration-ios-nxos.yaml
+++ b/lab-topologies/aaa-tacacs-exploration/aaa-exploration-ios-nxos.yaml
@@ -499,6 +499,7 @@ nodes:
             - bison
             - libwrap0-dev
             - python3.10-venv
+            - libnsl-dev
 
           write_files:
             # Create the tac_plus configuration file


### PR DESCRIPTION
`tac_plus` package build fails without `libnsl-dev` on recent
Ubuntu versions. This change updates the `aaa-tacacs-exploration`
lab topology YAML files.

Without `libnsl-dev`, I'm getting this error during the build:
```
configure:3969: checking whether the C compiler works
configure:3991: gcc   -I/usr/local/include  -L/usr/local/lib -L/lib conftest.c -lnsl -lcrypt  >&5
/usr/bin/ld: cannot find -lnsl: No such file or directory
collect2: error: ld returned 1 exit status
```

I'm using CML-Personal 2.8.1
`tacacs-server` image: Ubuntu 24.04

I haven't tested other versions.