### PR TITLE
Fix typo in `ccna-prep: s1e3` STP VLAN range

### DIFF
--- a/lab-topologies/ccna-prep/s1e3/CCNA_Prep_2024_S1E3_EtherChannel.yaml
+++ b/lab-topologies/ccna-prep/s1e3/CCNA_Prep_2024_S1E3_EtherChannel.yaml
@@ -898,7 +898,7 @@ nodes:
           !
           ! Setup spanning-tree
           spanning-tree mode rapid
-          spanning-tree vlan 1-4096 priority 49152
+          spanning-tree vlan 1-4094 priority 49152
           !
           ! Create VLANs
           vlan 10

--- a/lab-topologies/ccna-prep/s1e3/CCNA_Prep_2024_S1E3_EtherChannel.yaml
+++ b/lab-topologies/ccna-prep/s1e3/CCNA_Prep_2024_S1E3_EtherChannel.yaml
@@ -803,7 +803,7 @@ nodes:
           !
           ! Setup spanning-tree
           spanning-tree mode rapid
-          spanning-tree vlan 1-4096 priority 49152
+          spanning-tree vlan 1-4094 priority 49152
           !
           ! Create VLANs
           vlan 10


### PR DESCRIPTION
This fixes a typo in the `ALS1` and `ALS2` switches of the `s1e3` CCNA prep lab.

During startup, the switches show a telltale error:

```
% Command rejected: Bad instance list: Character #7 delimits a number which is out of the range (1..4094)
```

The startup config for the devices both list `1-4096` instead of `1-4094`, which this small patch should address. Otherwise, the startup causes them to default their STP priority to `32768` instead of `49152`.