### PR TITLE
Update virl2-migrate-data.sh to 2.4.2 from CML 2.10.0

### DIFF
--- a/scripts/migration-tool/README.md
+++ b/scripts/migration-tool/README.md
@@ -2,11 +2,11 @@
 
 The `virl2-migrate-data.sh` script allows you to copy CML configuration, lab, node, and image data between two CML servers.  Copying can be done "online" whereby the data is copied directly from one system to another; or "offline" where the data is first archived, and then the archive can be transferred to the new system and then extracted.
 
-You can also migration between CML 2.2 and CML 2.3.  This is a special case as the underlying OS has changed from CentOS to Ubuntu.  Both online and offline migrations are supported.
+You can also use this script to migrate between supported CML versions.  The current release supports source servers running CML 2.6.x through 2.10.x and target servers running CML 2.8.x through 2.10.x.  Both online and offline workflows are supported, and the script auto-detects when a version migration (rather than a same-version copy) is required.
 
 The script requires the following:
 
-- Both CML servers must be running the *exact same version of CML* (unless doing a version migration).
+- The source and target CML servers must be running supported versions (see above).  For a straight data copy without a version change, both servers must be on the *exact same version of CML*.
 - The target CML server must have sufficient disk space to copy all of the data from the source CML server (in online operation).
 - The source server must have sufficient disk space to hold an archive of all of its data (in offline operation).
 
@@ -93,13 +93,9 @@ To perform an offline, archive file copy, run the following command on the sourc
 sudo /usr/local/bin/virl2-migrate-data.sh --backup --file /path/to/archive.tar
 ```
 
-If you will be doing a version migration (i.e., from 2.2 to 2.3), run the following command instead:
+The same command is used regardless of whether you are doing a same-version data copy or a version migration; the script inspects the source and target CML versions and adjusts its behavior automatically.
 
-```bash
-sudo /usr/local/bin/virl2-migrate-data.sh --backup --migration --file /path/to/archive.tar
-```
-
-You can specify a file path for the archive where ever you have the requisite disk space.  The backup command will perform some source checks and then create this archive tar file.
+You can specify a file path for the archive wherever you have the requisite disk space.  The backup command will perform some source checks and then create this archive tar file.
 
 Once the backup portion completes, transfer this archive file to the target CML server.  How you do this transfer is up to you.  Using an intermediate SFTP or SCP server might be the easiest way.
 
@@ -126,3 +122,5 @@ This step isn't typically required, but if you are running into problems it can 
 This script is distributed as-is without formal support.  While it has been tested to work, it cannot anticipate all conditions of the source and target CML servers and may not properly copy all data in all cases.  Prior to running the script, you should have a backup of the source CML server (and/or VMware snapshot) just in case something goes wrong.  You should also wait to delete the source server after migration until you have thoroughly tested the target and confirm all functionality is properly working.
 
 If you have renamed the *sysadmin* user, you must pass the `--user` parameter to the migration command when doing online migration/copying.  For example: `--user cmladmin`.
+
+Likewise, if the source CML server's sysadmin SSH service is reachable on a non-default port, pass `--port <port>` (the default is `1122`).  For unattended invocations the script also accepts `--no-confirm` to skip the interactive confirmation prompts.

--- a/scripts/migration-tool/virl2-migrate-data.sh
+++ b/scripts/migration-tool/virl2-migrate-data.sh
@@ -1,487 +1,439 @@
 #!/bin/bash
 #
 # This file is part of VIRL 2
-# Copyright (c) 2019-2023, Cisco Systems, Inc.
+# Copyright (c) 2019-2026, Cisco Systems, Inc.
 # All rights reserved.
 #
 
-source /etc/default/virl2
+# the sysadmin username in the source server for online migration
+DEFAULT_USER="sysadmin"
+
+ME=$(basename "$0")
+LOCAL_ME=$0
+OTHER_ME=/tmp/$ME
+DEF_FILE=/etc/default/virl2
+source "$DEF_FILE"
+: "${IS_CONNECTOR:=1}"
+set -euo pipefail
 
 # Version of this script in semver 2.0 format.
-_VERSION="2.0.4"
+_VERSION="2.4.3"
+
+# Supported versions of source and target hosts for upgrade
+# The max versions are above last supported version
+SOURCE_MIN=2.6.0
+SOURCE_MAX=2.11.0
+TARGET_MIN=2.8.0
+TARGET_MAX=2.11.0
+
+# Flag whether source and target have potential LXC nodes
+SOURCE_LXC=false
+TARGET_LXC=false
 
 # The branch from which to grab the canonical, stable latest version of the script.
 GITHUB_BRANCH="master"
 
 # This is the link to the raw GitHub source for the script itself.
-GITHUB_URL="https://raw.githubusercontent.com/CiscoDevNet/cml-community/${GITHUB_BRANCH}/scripts/migration-tool/virl2-migrate-data.sh"
+GITHUB_URL="https://raw.githubusercontent.com/CiscoDevNet/cml-community/$GITHUB_BRANCH/scripts/migration-tool/virl2-migrate-data.sh"
 
-SRC_DIRS="${BASE_DIR}/images ${CFG_DIR}"
+# Services which need stopping and restarting
+CML_SERVICES=(virl2.target)
+# Source directories; the array items are sometimes used unquoted
+IMG_DIR="$BASE_DIR/images"
+SRC_DIRS=("$IMG_DIR")
+if [[ "$IS_CONNECTOR" == 1 ]]; then
+    # only controllers hold DB, image and node definitions
+    SRC_DIRS+=("$CFG_DIR" "$LIBVIRT_IMAGES")
+fi
+
 KEY_FILE="migration_key"
+CFG_FILE="migration_cfg"
 SSH_PORT="1122"
-DOING_MIGRATION=0
-DEFAULT_USER="sysadmin"
-MIGRATION_MAP="/var/lib/libvirt/images:${LIBVIRT_IMAGES}"
+# marker for check_disk_size to calculate required size from list of paths
+DU="_calculate_"
+# Migration here means upgrade from a supported release to a current one
+DOING_MIGRATION=false
 HOSTNAME=$(hostname --short)
+IOL_RUNNER="iol-runner-*.tar.gz"
+# Files that should not be packed up: failed metadata patches, sockets, IOL base image
+EXCLUDES=("--exclude="{"*."{rej,orig,sock},"netio*/[t0-9]*","$IOL_RUNNER"})
+# Contains all persistent domains and networks under subdirectories that need not exist
+LIBVIRT_XML="/etc/libvirt"
 
 # Compute a timestamp, avoiding colons so that it's easier to use in filenames.
 TIMESTAMP=$(printf '%(%Y-%m-%d_%H-%M-%S_%Z)T')
 
+# Progress indicator config for tar
+tar_checkpoint_action=' printf "\e[1;34m%s of %s copied  %d/100%% complete  \e[0m\r" '
+tar_checkpoint_action+='$(numfmt --to=iec-i $((10000*$TAR_CHECKPOINT)) ) '
+tar_checkpoint_action+='$(numfmt --to=iec-i $((10000*$total)) )\t'
+tar_checkpoint_action+='$((100*$TAR_CHECKPOINT/$total)) '
+
 check_for_updates() {
-    gh_version=$(curl -s ${GITHUB_URL} | grep "^_VERSION")
-    if [ -z "${gh_version}" ]; then
+    local rc=0
+    curl -s --output "$OTHER_ME" "$GITHUB_URL" || rc=$?
+    if [[ $rc != 0 ]]; then
+        echo "Failed to download GitHub source.  Not updating."
+        return $rc
+    fi
+
+    gh_version=$(sed -n -e '/^_VERSION=/{s/.*="\([^"]*\)"/\1/p;q}' "$OTHER_ME")
+    if [[ -z "$gh_version" ]]; then
         echo "Unable to find version from GitHub source.  Not updating."
         return 1
     fi
 
-    gh_version="_GH${gh_version}"
-    eval "${gh_version}"
-
-    if [ "${_GH_VERSION}" = "${_VERSION}" ]; then
-        echo "GitHub source version is the same as the current version.  Not updating."
+    if dpkg --compare-versions "$gh_version" le "$_VERSION"; then
+        echo "GitHub source version is not newer than the current version.  Not updating."
         return 0
     fi
 
-    curl -s --output ${LOCAL_ME} ${GITHUB_URL}
-    rc=$?
-    if [ ${rc} != 0 ]; then
-        echo "Failed to download GitHub source.  Not updating."
-        return ${rc}
-    fi
+    cp -b -S ".$_VERSION" "$OTHER_ME" "$LOCAL_ME"
+    chmod +x "$LOCAL_ME"
 
-    chmod +x ${LOCAL_ME}
-
-    echo "Successfully updated to ${_GH_VERSION}.  Please re-run ${LOCAL_ME}."
+    echo "Successfully updated to $gh_version.  Please re-run $LOCAL_ME."
 
     return 0
+}
+
+grepok() {
+    # Exit 0 even if 0 lines are output
+    grep "$@" || true
+}
+
+ask_confirm() {
+    if ! $NO_CONFIRM; then
+        read -r -p "$1 [y/N] " confirm
+        echo
+        if [[ "$confirm" != y* ]]; then
+            echo "Terminating $2."
+            exit 0
+        fi
+    fi
+}
+
+cleanup_local() {
+    set +e
+    if [[ -n "$WORKING_DIR" && -d "$WORKING_DIR" ]]; then
+        rm -rf "$WORKING_DIR"
+    fi
 }
 
 cleanup_backup() {
+    set +e
     echo
     echo "Cleaning up..."
     echo
 
-    if [ -n "${tempd}" ]; then
-        rm -rf "${tempd}"
-    fi
-    if [ -n "${ddir}" ]; then
-        rm -rf "${ddir}"
-    fi
-    if [ -n "${ndir}" ]; then
-        rm -rf "${ndir}"
-    fi
-    if [ -n "${idir}" ]; then
-        rm -rf "${idir}"
-    fi
-
-    if [ ${DOING_MIGRATION} -eq 1 ]; then
-        umount_refplat_overlay 2>/dev/null
-    fi
-
     restart_cml_services
+    cleanup_local
 
-    if [ -z "${rc}" ]; then
+    if [[ -z "${rc:-}" ]]; then
         rc=1
     fi
 
-    if [ ${rc} != 0 ]; then
-        rm -f "${BACKUP_FILE}"
+    if [[ $rc != 0 ]]; then
+        rm -f "$BACKUP_FILE"
     fi
 
-    exit ${rc}
+    exit $rc
 }
 
 cleanup_failed_restore() {
+    set +e
     echo
     echo "Cleaning up..."
     echo
 
-    if [ -n "${ddir}" ]; then
-        rm -rf "${ddir}"
-    fi
-    if [ -n "${ndir}" ]; then
-        rm -rf "${ndir}"
-    fi
-    if [ -n "${idir}" ]; then
-        rm -rf "${idir}"
-    fi
-
     restart_cml_services
+    cleanup_local
 
-    if [ -z "${rc}" ]; then
+    if [[ -z "${rc:-}" ]]; then
         rc=1
     fi
 
-    exit ${rc}
+    exit $rc
+}
+
+cleanup_remote_from_host() {
+    set +e
+    # Path chosen by --prepare-export on the source host.
+    local remote_dir=${REMOTE_WORK_DIR:-}
+    ssh "${ssh_opts[@]}" "$host" \
+        "sudo $OTHER_ME --start; \
+        sudo rm -rf ${remote_dir:+\"$remote_dir\"} $OTHER_ME /etc/sudoers.d/cml-migrate; \
+        (cp -fa ~/.ssh/authorized_keys{.migration,} &>/dev/null || true)"
 }
 
 cleanup_failed_from_host() {
+    set +e
     echo
-    echo "Cleaning up..."
+    echo "Cleaning up on remote host..."
     echo
 
-    if [ ${DOING_MIGRATION} -eq 1 ]; then
-        ssh -o "StrictHostKeyChecking=no" -i "${key_dir}"/${KEY_FILE} -p ${SSH_PORT} "${sysadmin_user}"@"${host}" "sudo /tmp/${ME} --umount-overlay"
-    fi
+    cleanup_remote_from_host
+    restart_cml_services
+    cleanup_local
 
-    ssh -o "StrictHostKeyChecking=no" -i "${key_dir}"/${KEY_FILE} -p ${SSH_PORT} "${sysadmin_user}"@"${host}" "sudo /tmp/${ME} --start && sudo rm -rf ${libvirt_domains} && sudo rm -f /tmp/${ME} && sudo rm -f /etc/sudoers.d/cml-migrate && (cp -fa ~/.ssh/authorized_keys.migration ~/.ssh/authorized_keys >/dev/null 2>&1 || true)"
-
-    if [ -z "${rc}" ]; then
+    if [[ -z "${rc:-}" ]]; then
         rc=1
     fi
 
-    cleanup_from_host "${key_dir}"
-
-    exit ${rc}
+    exit $rc
 }
 
 set_virl_version() {
-    product_file=/PRODUCT
-    if [ $# = 1 ]; then
-        product_file=$1
-    fi
+    local product_file=${1:-/PRODUCT}
+    local version
+    version=$(jq -r ".PRODUCT_VERSION" <"$product_file" | sed -e 's/-.*//')
 
-    vers=$(jq -r ".PRODUCT_VERSION" <"${product_file}")
-
-    if [ $# = 1 ]; then
-        echo ${vers}
+    if [[ $# == 1 ]]; then
+        echo "$version"
     else
-        VIRL_VERSION=${vers}
+        VIRL_VERSION=$version
     fi
 }
 
-needs_overlay() {
-    major_ver=$(echo ${VIRL_VERSION} | cut -d'.' -f1)
-    minor_ver=$(echo ${VIRL_VERSION} | cut -d'.' -f2)
-    if [ "${major_ver}" -gt 2 ] || ([ "${major_ver}" -eq 2 ] && [ "${minor_ver}" -ge 3 ]); then
-        return 1
-    fi
-
-    return 0
+copy_xml() {
+    find "$origin" -maxdepth 1 -name '*.xml' -print0 | xargs -0 -r cp -t "$target"
 }
 
-mount_refplat_overlay() {
-    if ! needs_overlay; then
-        return 0
-    fi
-
-    # create required directories, if needed
-    [ -d $REF_PLAT/cdrom ] || mkdir -p $REF_PLAT/cdrom
-    [ -d $REF_PLAT/diff ] || mkdir -p $REF_PLAT/diff
-    [ -d $REF_PLAT/work ] || mkdir -p $REF_PLAT/work
-
-    if [ $REF_PLAT != $LIBVIRT_IMAGES ]; then
-        MOUNT_POINT=$REF_PLAT/cdrom
-    else
-        MOUNT_POINT=$LIBVIRT_IMAGES
-    fi
-
-    # if overlayfs is mounted, do nothing
-    mount | grep -q "^overlay on $LIBVIRT_IMAGES"
-    if [ $? -eq 0 ]; then
-        return 0
-    fi
-
-    # try to mount the CDROM. If none is present it will continue
-    # it will just give an error for the mount like
-    # "mount: /var/local/virl2/refplat/cdrom: no medium found on /dev/sr0."
-    if [ -f "$REF_PLAT_ISO_IMAGE" ]; then
-        ! test -d $MOUNT_POINT && mkdir $MOUNT_POINT
-        if ! mount -t iso9660 -oloop,fscontext=$CONTEXT $REF_PLAT_ISO_IMAGE $MOUNT_POINT; then
-            echo "no refplat ISO image present / mounted!"
-            return 1
-        fi
-    elif [ -d "$REF_PLAT_DIR" ]; then
-        if test -d "$REF_PLAT_DIR"; then
-            test -d $MOUNT_POINT && rmdir $MOUNT_POINT
-            ln -s $REF_PLAT_DIR $MOUNT_POINT
+prepare_export() {
+    {
+        printf "# CML2 migration on %s.\n" "$(date)"
+        printf "\n## hostname \n"
+        hostname
+        printf "\n## ip link show \n"
+        ip link show
+        printf "\n## nmcli \n"
+        if nmcli; then
+            printf "\n## nmcli con show \n"
+            nmcli con show
+            printf "\n## nmcli con show bridge0 \n"
+            nmcli con show bridge0
         else
-            echo "no refplat ISO image present / mounted!"
-            return 1
+            echo "NetworkManager is not available"
         fi
-    else
-        ! test -d $MOUNT_POINT && mkdir $MOUNT_POINT
-        if ! mount $CDROM_DEVICE; then
-            echo "no refplat CD-ROM present / mounted!"
-            return 1
-        fi
+    } >"$CFG_DIR"/migration_info.txt
+
+    mkdir -p "$WORKING_DIR"/{kvm,net}
+    local target="$WORKING_DIR/kvm" origin="$LIBVIRT_XML/qemu"
+    if [ -d "$origin" ]; then
+        copy_xml
     fi
 
-    # mount the libvirt image directory in an OverlayFS
-    if [ $REF_PLAT != $LIBVIRT_IMAGES ]; then
-        mount -t overlay overlay \
-            -ofscontext=$CONTEXT,lowerdir=$REF_PLAT/cdrom,upperdir=$REF_PLAT/diff,workdir=$REF_PLAT/work \
-            $LIBVIRT_IMAGES
-        if [ $? != 0 ]; then
-            echo "error mounting overlay filesystem"
-            return 1
-        fi
+    origin="$LIBVIRT_XML/lxc"
+    if "$SOURCE_LXC" && [ -d "$origin" ]; then
+        target="$WORKING_DIR/lxc"
+        mkdir -p "$target"
+        copy_xml
     fi
 
-    return 0
+    origin="$LIBVIRT_XML/qemu/networks"
+    if [ -d "$origin" ]; then
+        target="$WORKING_DIR/net"
+        copy_xml
+    fi
+
+    cp "$DEF_FILE" "$WORKING_DIR/$CFG_FILE"
 }
 
-umount_refplat_overlay() {
-    if ! needs_overlay; then
+perform_restore() {
+    reconfigure_host
+    import_libvirt_resources
+    if $DOING_MIGRATION; then
+        migrate_host
+    fi
+    if dpkg --compare-versions "$VIRL_VERSION" ge 2.9.1 && systemctl is-enabled virl2-core-driver &>/dev/null; then
+        /usr/local/bin/virl2-core-driver.sh upgrade
+    fi
+    /usr/local/bin/virl2-lowlevel-driver.sh upgrade
+}
+
+migrate_host() {
+    # DB migration only on the controller
+    if [[ "$IS_CONNECTOR" != 1 ]]; then
         return 0
     fi
-
-    umount ${LIBVIRT_IMAGES}
-    return $?
-}
-
-build_local_src_dirs() {
-    if [ ${DOING_MIGRATION} -eq 1 ]; then
-        return
-    fi
-
-    # In CML 2.3+ we no longer have the overlay.
-    if ! needs_overlay; then
-        SRC_DIRS="${SRC_DIRS} ${LIBVIRT_IMAGES}"
-        return
-    fi
-
-    if [ "${REF_PLAT}" != "${LIBVIRT_IMAGES}" ]; then
-        MOUNT_POINT=${REF_PLAT}/cdrom
+    echo "Performing DB migration..."
+    local rc=0
+    local output
+    output=$( (
+        chown -R www-data:www-data "$CFG_DIR"
+        find "$BASE_DIR"/images -xdev -type f \( -name "*.img" -or -name "nodedisk*" \) -print0 |
+            xargs -0 chown libvirt-qemu:kvm 2>/dev/null
+        # env vars should match expected variables in postinst alembic upgrade
+        cd "$BASE_DIR"/db_migrations &&
+            env CFG_DIR="$CFG_DIR" BASE_DIR="$BASE_DIR" VIRL2_DIR="$BASE_DIR" HOME="$BASE_DIR" \
+                COMPUTE_ID="$COMPUTE_ID" MIGRATION=1 HOSTNAME="$HOSTNAME" \
+                "$BASE_DIR"/.local/bin/alembic upgrade head
+    ) 2>&1) || rc=$?
+    if [[ $rc != 0 ]]; then
+        echo "Failed to execute data upgrade scripts:"
+        printf '%s\n\n' "$output"
+        return $rc
     else
-        MOUNT_POINT=${LIBVIRT_IMAGES}
+        echo "Migration completed SUCCESSFULLY."
     fi
+}
 
-    if [ -d "${REF_PLAT_DIR}" ]; then
-        MOUNT_POINT="${REF_PLAT_DIR}"
+reconfigure_host() {
+    local cfg_file="$WORKING_DIR"/"$CFG_FILE"
+    local extract_id='/^COMPUTE_ID=/{s/.*=[^0-9a-fA-F]\?\([0-9a-fA-F-]\{36\}\).*/\1/p;q}'
+    local helper="/usr/local/bin/virl2-issue-helper.sh"
+    local compute_id
+    compute_id=$(sed -n -e "$extract_id" "$cfg_file")
+    if [[ -n "$compute_id" ]]; then
+        sed -i -e 's/^\(COMPUTE_ID=\).*/\1"'"$compute_id"'"/' "$DEF_FILE"
+        if [[ -x "$helper" ]]; then
+            "$helper"
+        fi
+        echo "Host compute ID has been set to $compute_id"
     fi
+}
 
-    WRKDIR="${REF_PLAT}"/diff
-
-    # Find all custom node defs
-    new_node_defs=$(find "${WRKDIR}"/node-definitions/ -maxdepth 1 -type f -name "*.yaml")
-    old_IFS=${IFS}
-    IFS='
-'
-    for nd in ${new_node_defs}; do
-        fname=$(basename "${nd}")
-        if [ ! -f "${MOUNT_POINT}"/node-definitions/"${fname}" ]; then
-            SRC_DIRS="${SRC_DIRS} ${nd}"
-        else
-            if ! diff -q "${nd}" "${MOUNT_POINT}"/node-definitions/"${fname}" >/dev/null 2>&1; then
-                SRC_DIRS="${SRC_DIRS} ${nd}"
-            fi
+import_libvirt_resources() {
+    local rc=0
+    local resource
+    for resource in domain network; do
+        local output
+        output=$(define_${resource}s 2>&1) || rc=$?
+        if [[ $rc != 0 ]]; then
+            echo "Libvirt $resource import completed with errors:"
+            printf '%s\n\n' "$output"
+            return $rc
         fi
     done
-
-    # Find all custom image defs
-    new_image_defs=$(find "${WRKDIR}"/virl-base-images/ -maxdepth 1 -type d)
-
-    for id in ${new_image_defs}; do
-        if [ "${id}" = "${WRKDIR}"/virl-base-images/ ]; then
-            continue
-        fi
-        dname=$(basename "${id}")
-        if [ ! -d "${MOUNT_POINT}"/virl-base-images/"${dname}" ]; then
-            SRC_DIRS="${SRC_DIRS} ${id}"
-        fi
-    done
-
-    IFS=${old_IFS}
-}
-
-export_network_configuration() {
-    outfile=${CFG_DIR}/migration_info.txt
-    printf "# CML2 migration on $(date).\n" >> ${outfile}
-    printf "\n## nmcli con show \n" >> ${outfile}
-    nmcli con show >> ${outfile}
-    printf "\n## ip link show \n" >> ${outfile}
-    ip link show >> ${outfile}
-    printf "\n## nmcli con show bridge0 \n" >> ${outfile}
-    nmcli con show bridge0 >> ${outfile}
-    printf "\n## nmcli \n" >> ${outfile}
-    nmcli >> ${outfile}
-    printf "\n## hostname \n" >> ${outfile}
-    hostname >> ${outfile}
-}
-
-export_libvirt_domains() {
-    ddir=$(mktemp -d /tmp/libvirt_domains.XXXXX)
-    domains=$(virsh list --all --name)
-    if [ $? != 0 ]; then
-        echo "${ddir}"
-        return $?
+    if [[ $rc == 0 ]]; then
+        echo "Restore completed SUCCESSFULLY."
     fi
-
-    old_IFS=${IFS}
-    IFS='
-'
-
-    for domain in ${domains}; do
-        virsh dumpxml "${domain}" >"${ddir}"/"${domain}".xml
-    done
-
-    IFS=${old_IFS}
-
-    echo "${ddir}"
+    return $rc
 }
 
-export_libvirt_networks() {
-    ndir=$(mktemp -d /tmp/libvirt_networks.XXXXX)
-    networks=$(virsh net-list --all --name | grep -v "^default")
-    if [ $? != 0 ]; then
-        echo "${ndir}"
-        return $?
+list_resources() {
+    local resource=$1
+    local resource_dir="$WORKING_DIR/$resource"
+    if [[ -d "$resource_dir" ]]; then
+        find "$resource_dir" -name '*.xml'
     fi
-
-    old_IFS=${IFS}
-    IFS='
-'
-
-    for network in ${networks}; do
-        virsh net-dumpxml "${network}" >"${ndir}"/"${network}".xml
-    done
-
-    IFS=${old_IFS}
-
-    echo "${ndir}"
-}
-
-export_libvirt_ifaces() {
-    idir=$(mktemp -d /tmp/libvirt_ifaces.XXXXX)
-    ifaces=$(virsh net-list --all | grep "^[[:space:]]*bridge" | awk '{print $1}' | grep -v "^bridge0")
-    if [ $? != 0 ]; then
-        echo "${idir}"
-        return $?
-    fi
-
-    old_IFS=${IFS}
-    IFS='
-'
-
-    for iface in ${ifaces}; do
-        virsh iface-dumpxml "${iface}" --inactive >"${idir}"/"${iface}".xml
-    done
-
-    IFS=${old_IFS}
-
-    echo "${idir}"
 }
 
 define_domains() {
-    ddir=$1
+    local rc=0
+    local resource_xml
+    while read -r resource_xml <&3; do
+        virsh define "$resource_xml" || rc=$?
+        if [[ $rc != 0 ]]; then
+            return $rc
+        fi
+    done 3< <(list_resources kvm)
 
-    if [ ! -d "${ddir}" ]; then
-        echo "${ddir}: No such directory"
-        return 1
-    fi
-
-    ls -1 "${ddir}"/*.xml >/dev/null 2>&1
-    if [ $? != 0 ]; then
+    if ! "$SOURCE_LXC"; then
         return 0
     fi
 
-    old_IFS=${IFS}
-    IFS='
-'
-
-    for domain in "${ddir}"/*.xml; do
-        virsh define "${domain}"
-        if [ $? != 0 ]; then
-            rc=$?
-            IFS=${old_IFS}
-            return ${rc}
+    if ! "$TARGET_LXC"; then
+        # All LXC nodes are IOL, hence prepare them for conversion to Docker
+        local node_id
+        local -a node_dirs
+        while read -r resource_xml <&3; do
+            node_id="$(basename "$resource_xml" .xml)"
+            node_dirs=("$BASE_DIR/images/"*"/$node_id/")
+            if [[ -d "${node_dirs[0]}" ]]; then
+                mv "$resource_xml" "${node_dirs[0]}/domain.xml"
+            fi
+        done 3< <(list_resources lxc)
+        return 0
+    fi
+    while read -r resource_xml <&3; do
+        virsh -c lxc:/// define "$resource_xml" || rc=$?
+        if [[ $rc != 0 ]]; then
+            return $rc
         fi
-    done
+    done 3< <(list_resources lxc)
+}
 
-    IFS=${old_IFS}
+undefine_network_if_exists() {
+    local network="$1"
+    local rc=0
+    local state
+    state=$(virsh net-info "$network" 2>/dev/null) || rc=$?
+    if [[ $rc != 0 ]]; then
+        return 0
+    fi
+    if grep -q 'Active:.*yes' <<<"$state"; then
+        virsh net-destroy "$network"
+    fi
+    virsh net-undefine "$network"
 }
 
 define_networks() {
-    ndir=$1
-
-    if [ ! -d "${ndir}" ]; then
-        echo "${ndir}: No such directory"
-        return 1
-    fi
-
-    ls -1 "${ndir}"/*.xml >/dev/null 2>&1
-    if [ $? != 0 ]; then
-        return 0
-    fi
-
-    old_IFS=${IFS}
-    IFS='
-'
-
-    for network in "${ndir}"/*.xml; do
-        virsh net-define "${network}"
-        if [ $? != 0 ]; then
-            rc=$?
-            IFS=${old_IFS}
-            return ${rc}
+    local resource_xml
+    while read -r resource_xml <&3; do
+        local network
+        network=$(basename "$resource_xml" .xml)
+        if [[ "$network" == default ]] && ! grep -q 'cml:cml' "$resource_xml"; then
+            # Maybe we should skip all networks which are not marked by CML
+            echo "Skipping import of default network as it is not adjusted for cml"
+            continue
         fi
-    done
-
-    IFS=${old_IFS}
+        undefine_network_if_exists "$network"
+        virsh net-define "$resource_xml"
+        if [[ "$network" != ums-* ]]; then
+            virsh net-start "$network"
+        fi
+    done 3< <(list_resources net)
 }
 
-define_ifaces() {
-    idir=$1
-
-    if [ ! -d "${idir}" ]; then
-        echo "${idir}: No such directory"
-        return 1
+prepare_local() {
+    local rc=0
+    stop_cml_services || rc=$?
+    if [[ $rc != 0 ]]; then
+        echo "Failed to stop CML services."
+        return $rc
+    fi
+    {
+        delete_libvirt_domains
+        delete_libvirt_networks
+    } || rc=$?
+    if [[ $rc != 0 ]]; then
+        echo "Failed to remove pre-existing node and network resources."
+        return $rc
     fi
 
-    ls -1 "${idir}"/*.xml >/dev/null 2>&1
-    if [ $? != 0 ]; then
-        return 0
+    # Remove stale SQLite WAL/SHM so they are not replayed onto the
+    # freshly synced controller.db ("database disk image is malformed").
+    if [[ "$IS_CONNECTOR" == 1 ]]; then
+        rm -f "$CFG_DIR"/controller.db-wal "$CFG_DIR"/controller.db-shm
     fi
-
-    old_IFS=${IFS}
-    IFS='
-'
-
-    for iface in "${idir}"/*.xml; do
-        virsh iface-define "${iface}"
-        if [ $? != 0 ]; then
-            rc=$?
-            IFS=${old_IFS}
-            return ${rc}
-        fi
-    done
-
-    IFS=${old_IFS}
+    return $rc
 }
 
 delete_libvirt_domains() {
-    for domain in $(virsh list --all --name); do
-        virsh undefine "${domain}" >/dev/null
-    done
+    virsh list --all --name | grepok -v '^ *$' | xargs -rn1 virsh undefine --nvram >/dev/null
+    if "$TARGET_LXC"; then
+        virsh -c lxc:/// list --all --name | grepok -v '^ *$' | xargs -rn1 virsh -c lxc:/// undefine >/dev/null
+    fi
 }
 
 delete_libvirt_networks() {
-    for network in $(virsh net-list --all --name | grep -v "^default"); do
-        virsh net-undefine "${network}" >/dev/null
-    done
-}
-
-delete_libvirt_ifaces() {
-    for iface in $(virsh iface-list --all | grep "^[[:space:]]*bridge" | awk '{print $1}' | grep -v "^bridge0"); do
-        virsh iface-undefine "${iface}" >/dev/null
-    done
+    virsh net-list --all --name | grepok "^ums" | xargs -rn1 virsh net-undefine >/dev/null
 }
 
 check_disk_space() {
-    source=$1
-    target=$2
-
-    if [ -z "${source}" ] && [ $# = 3 ]; then
-        total_needed=$3
-    else
-        total_needed=$(du -B1 -sc ${source} | grep total | sed -E -s 's|\s+total||')
+    local target=$1
+    local total_needed=$2
+    if [[ "$total_needed" == "$DU" ]]; then
+        shift 2
+        total_needed=$(du -B1 -sc "$@" | sed -n -E -e 's|\s+total||p')
     fi
 
-    total_available=$(df -B1 --output=avail "${target}" | grep -E '[0-9]')
+    local total_available mount_point
+    read -r total_available mount_point < <(df -B1 --output=avail,target "$target" | grep '^[0-9]')
 
-    if [ "${total_needed}" -gt "${total_available}" ]; then
-        echo "Insufficient disk space required in ${target}; ${total_needed} bytes required but only ${total_available} bytes available."
+    if [[ "$total_needed" -gt "$total_available" ]]; then
+        echo "Insufficient disk space available in $mount_point for $target;"
+        echo "$total_needed bytes required but only $total_available bytes available."
         return 1
     fi
 
@@ -489,375 +441,276 @@ check_disk_space() {
 }
 
 wait_for_vms_to_stop() {
-    # this is only needed if VMs are running on the
-    # controller where the ISO is mounted.
-    loops=5 # max 5x5 = 25s
-    done=0
-    while ((loops > 0 && !done)); do
-        done=1
-        for vm in $(virsh -c qemu:///system list --all --name); do
-            if [[ "$vm" =~ ^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12} ]]; then
-                vm_state=$(virsh dominfo "$vm")
-                if [[ "$vm_state" =~ State:\ +running ]]; then
-                    echo "still running: $vm"
-                    done=0
-                fi
-            fi
-        done
-        ((loops -= 1))
-        ((!done)) && sleep 5
-    done
-    if ((!done)); then
-        echo "Some labs are still running; please stop all labs before continuing"
-        return 1
+    local -i loops=5 # max 5x5 = 25s
+    local have_docker=false check_libvirt=true check_docker=true
+    if type docker &>/dev/null; then
+        have_docker=true
     fi
+    if ! pgrep libvirtd &>/dev/null; then
+        echo "Libvirt service is not running and node state cannot be determined."
+        ask_confirm "Assume all VMs have been properly stopped?" "pre-check"
+        check_libvirt=false
+    fi
+    if "$have_docker" && ! pgrep dockerd &>/dev/null; then
+        echo "Docker service is not running and node state cannot be determined."
+        ask_confirm "Assume all containers have been properly stopped?" "pre-check"
+        check_docker=false
+    fi
+    while [[ $loops -gt 0 ]]; do
+        local running
+        running=$({
+            if "$check_libvirt"; then
+                virsh list --name
+                virsh -c lxc:/// list --name
+            fi
+            if "$have_docker" && "$check_docker"; then
+                docker ps --format '{{.Names}}'
+            fi
+        } | grepok -vc '^ *$')
+        if [[ "$running" == 0 ]]; then
+            return 0
+        fi
+        echo "Still running $running nodes"
+        loops+=-1
+        sleep 5
+    done
+    echo "Some labs are still running; please stop all labs before continuing"
+    return 1
 }
 
 stop_cml_services() {
-    #wait_for_vms_to_stop
-    rc=$?
-    if [ ${rc} != 0 ]; then
-        return ${rc}
+    local rc=0
+    wait_for_vms_to_stop || rc=$?
+    if [[ $rc != 0 ]]; then
+        return $rc
     fi
-    systemctl stop virl2.target
-    rc=$?
-    if [ ${rc} != 0 ]; then
-        return ${rc}
+    systemctl stop "${CML_SERVICES[@]}" || rc=$?
+    if [[ $rc != 0 ]]; then
+        return $rc
     fi
 
     echo "Waiting for controller to become inactive..."
-    while [ "$(systemctl is-active virl2-controller)" = "active" ]; do
+    while [[ "$(systemctl is-active virl2-controller)" == "active" ]]; do
         echo "  Still active..."
         sleep 5
     done
-    return ${rc}
+    return $rc
 }
 
 restart_cml_services() {
     echo "Restarting CML services..."
-    systemctl start virl2.target
+    systemctl --no-block start "${CML_SERVICES[@]}"
 }
 
-delete_local_dirs() {
-    dirs=$1
-
-    from=""
-    if [ $# -ge 2 ]; then
-        from=$2
-    fi
-
-    for dir in ${dirs}; do
-        echo "Deleting local directory ${from}${dir}"
-        rm -rf "${from}""${dir}"
-        if [ $# -lt 3 ]; then
-            echo "Creating directory ${from}${dir}"
-            mkdir -p "${from}""${dir}"
-        fi
-    done
-}
-
-generate_ssh_key() {
-    # Generate an SSH key we can use to avoid re-prompting for a password.
-    tempd=$(mktemp -d /tmp/migration.XXXXX)
-    ssh-keygen -b 4096 -q -N "" -f "${tempd}"/${KEY_FILE}
-    echo "${tempd}"
-}
-
-cleanup_from_host() {
-    key_dir=$1
-
-    rm -rf "${key_dir}"
-    restart_cml_services
-}
-
+# compatibility checks
+# also adjusts DOING_MIGRATION, CML_SERVICES and SRC_DIRS, it needs to be called
+# before those variables are used (e.g. prepare_local, check_disk_size)
 check_cml_versions() {
-    curr_ver=$1
-    src_ver=$2
-
-    if [ "${curr_ver}" = "${src_ver}" ]; then
-        return 0
+    # import and restore
+    local source_version=${1:-}
+    local target_version=$VIRL_VERSION
+    if [[ $# -eq 0 ]]; then
+        # export, backup, stop, start
+        source_version=$VIRL_VERSION
+        if dpkg --compare-versions "$VIRL_VERSION" lt "$TARGET_MIN"; then
+            target_version=$TARGET_MIN
+        fi
     fi
 
-    # Allow one to migrate from 2.2.x to 2.3+.
-    if echo "${curr_ver}" | grep -qE '^2\.[3-9]\.[0-9]' && echo "${src_ver}" | grep -qE '^2\.2\.'; then
-        DOING_MIGRATION=1
-        return 0
+    if dpkg --compare-versions "$target_version" lt $TARGET_MIN; then
+        echo "This tool no longer supports CML version '$target_version'."
+        echo "Please use the version matching your target host release"
+        return 1
+    elif dpkg --compare-versions "$target_version" ge $TARGET_MAX; then
+        # We don't know how to migrate onto future releases
+        echo "This tool does not support CML version '$target_version'."
+        echo "Please use the version matching your target host release"
+        return 1
     fi
 
+    if [[ -z "$source_version" ]]; then
+        return 0
+    fi
+    if dpkg --compare-versions "$source_version" lt $SOURCE_MIN; then
+        echo "This tool can no longer migrate CML version '$source_version'."
+        return 1
+    fi
+    if dpkg --compare-versions "$source_version" ge $SOURCE_MAX; then
+        echo "This tool does not support migration from CML version" \
+            "'$source_version' to '$target_version'."
+        echo "Please use the version matching your target host release"
+        return 1
+    fi
+    if dpkg --compare-versions "${source_version%%[+-]*}" gt "${target_version%%[+-]*}"; then
+        echo "The source host CML version is newer than this host's." \
+            "Cannot downgrade from '$source_version' to '$target_version'."
+        return 1
+    fi
+
+    if dpkg --compare-versions "$source_version" lt "$target_version"; then
+        DOING_MIGRATION=true
+    fi
+    if dpkg --compare-versions "$source_version" ge 2.9.0; then
+        CML_SERVICES+=(docker{,.socket})
+        SRC_DIRS+=(/var/lib/docker/{containers,image,overlay2})
+    fi
+    if dpkg --compare-versions "$source_version" lt 2.10.0; then
+        SOURCE_LXC=true
+    fi
+    if dpkg --compare-versions "$target_version" lt 2.10.0; then
+        TARGET_LXC=true
+    fi
+
+    return 0
+}
+
+check_cml_is_connector() {
+    if [[ $IS_CONNECTOR == "$1" ]]; then
+        return 0
+    fi
+    echo "Only one of this host and original host are a controller"
+    echo "You must only migrate a controller to a controller, and each"
+    echo "compute host to a different compute host."
     return 1
 }
 
 sync_from_host() {
+    rc=0
     host=$1
-    host_ip="${host}"
+    host_ip="$host"
     # used in scp/rsync commands to support ipv6
-    scp_rsync_host="${host}"
-    if echo "${host_ip}" | grep -qE '[a-zA-Z]'; then
-        host_ip=$(host -t A "${host_ip}" | grep -oE '[0-9][0-9.]+')
-        if [ $? != 0 ]; then
-            echo "Failed to lookup host ${host}.  Please specify a valid IP or hostname."
+    scp_rsync_host="$host"
+    if grep -qE '[a-zA-Z]' <<<"$host_ip"; then
+        host_ip=$(host -t A "$host_ip" | grep -oE '[0-9][0-9.]+')
+        if [[ $? != 0 ]]; then
+            echo "Failed to lookup host $host.  Please specify a valid IP or hostname."
             return 1
         fi
-    elif echo "${host_ip}" | grep -qE '([0-9a-fA-F:]{1,5}){3,8}'; then
-        scp_rsync_host=\["${host}"\]
+    elif grep -qE '^([0-9a-fA-F:]{1,5}){3,8}$' <<<"$host_ip"; then
+        scp_rsync_host="[$host]"
     fi
-    if ip addr show | grep -q "inet6* ${host_ip}/"; then
+    if ip addr show | grep "inet6* $host_ip/" >/dev/null; then
         echo "You are trying to migrate from the local host.  Please specify another host from which to migrate."
         return 1
     fi
 
-    if ! nc -z "${host}" ${SSH_PORT}; then
+    if ! nc -z "$host" "$ssh_port"; then
         echo "Remote host does not have OpenSSH enabled; start the OpenSSH service from Cockpit on the source host."
         return 1
     fi
 
-    if [ ${NO_CONFIRM} -eq 0 ]; then
-        read -r -p "Do you wish to import data from ${host}? [y/N] " confirm
-        echo
-        if echo "${confirm}" | grep -viq '^y'; then
-            echo "Terminating import."
-            return 0
-        fi
-    fi
+    ask_confirm "Do you wish to import data from $host? This will replace current local data" "import"
 
-    stop_cml_services || (
-        echo "Failed to stop CML services."
-        exit $?
-    )
-    delete_libvirt_domains
-    delete_libvirt_networks
-    delete_libvirt_ifaces
+    ssh-keygen -b 4096 -q -N "" -f "$WORKING_DIR"/$KEY_FILE
+    key=$(<"$WORKING_DIR/$KEY_FILE.pub")
+    ssh_opts=(-o StrictHostKeyChecking=no -o Port="$ssh_port")
+    ssh_opts+=(-o User="$sysadmin_user" -i "$WORKING_DIR/$KEY_FILE")
 
-    key_dir=$(generate_ssh_key)
-    key=$(cat "${key_dir}"/${KEY_FILE}.pub)
-
-    printf "\nThe next prompt will be for %s's password on %s.\n" "${sysadmin_user}" "${host}"
-    printf "The prompt following that will be for %s's password on %s to enter sudo mode.\n\n" "${sysadmin_user}" "${host}"
+    printf "\nThe next prompt will be for %s's password on %s.\n" "$sysadmin_user" "$host"
+    printf "The prompt following that will be for %s's password on %s to enter sudo mode.\n\n" "$sysadmin_user" "$host"
     # Stop the service on the remote host and make sure we don't need
     # a password for sudo.  We also install the SSH pubkey for subsequent logins.
-    if ! ssh -o "StrictHostKeyChecking=no" -t -p ${SSH_PORT} "${sysadmin_user}"@"${host}" "echo '%${sysadmin_user}        ALL=(ALL)       NOPASSWD: ALL' | sudo tee /etc/sudoers.d/cml-migrate >/dev/null 2>&1 && mkdir -p ~/.ssh && \
-        chmod 0700 ~/.ssh && (cp -fa ~/.ssh/authorized_keys ~/.ssh/authorized_keys.migration >/dev/null 2>&1 || true) && echo ${key} | tee -a ~/.ssh/authorized_keys >/dev/null 2>&1 && chmod 0600 ~/.ssh/authorized_keys"; then
-        rc=$?
-        cleanup_from_host "${key_dir}"
-        echo "Error preparing ${host} for migration."
-        return ${rc}
+    ssh -t "${ssh_opts[@]}" "$host" "echo '%$sysadmin_user        ALL=(ALL)       NOPASSWD: ALL' |\
+        sudo tee /etc/sudoers.d/cml-migrate >/dev/null 2>&1 && mkdir -p ~/.ssh && \
+        chmod 0700 ~/.ssh && \
+        (cp -fa ~/.ssh/authorized_keys{,.migration} &>/dev/null || true) && \
+        echo $key | tee -a ~/.ssh/authorized_keys &>/dev/null && \
+        chmod 0600 ~/.ssh/authorized_keys" || rc=$?
+    if [[ $rc != 0 ]]; then
+        echo "Error preparing $host for migration."
+        return $rc
     fi
 
     # Install this script on the remote host.
-    if ! scp -o "StrictHostKeyChecking=no" -i "${key_dir}"/${KEY_FILE} -P ${SSH_PORT} "${LOCAL_ME}" "${sysadmin_user}"@"${scp_rsync_host}":"/tmp/${ME}" >/dev/null; then
-        rc=$?
-        cleanup_from_host "${key_dir}"
-        echo "Error copying /usr/local/bin/${ME} to source host."
-        return ${rc}
+    scp "${ssh_opts[@]}" "$LOCAL_ME" "$scp_rsync_host":"$OTHER_ME" >/dev/null || rc=$?
+    if [[ $rc != 0 ]]; then
+        echo "Error copying $LOCAL_ME to source host."
+        return $rc
     fi
 
-    # Stop CML services on remote host.
-    if ! ssh -o "StrictHostKeyChecking=no" -i "${key_dir}"/${KEY_FILE} -p ${SSH_PORT} "${sysadmin_user}"@"${host}" "sudo chmod +x /tmp/${ME} && sudo /tmp/${ME} --stop" 2>/dev/null; then
-        rc=$?
-        cleanup_from_host "${key_dir}"
-        echo "Failed to stop source CML services."
-        return ${rc}
-    fi
-
-    trap cleanup_failed_from_host SIGINT
-
+    echo "Checking remote host.."
     # Check CML versions on both hosts.
-    output=$( (ssh -o "StrictHostKeyChecking=no" -i "${key_dir}"/${KEY_FILE} -p ${SSH_PORT} "${sysadmin_user}"@"${host}" "sudo /tmp/${ME} --cml-version") 2>/dev/null)
-    if [ $? != 0 ]; then
-        rc=$?
-        cleanup_from_host "${key_dir}"
-        echo "Failed to determine remote CML version."
-        return ${rc}
+    output=$(ssh "${ssh_opts[@]}" "$host" "sudo $OTHER_ME --cml-identify") || rc=$?
+    if [[ $rc != 0 ]]; then
+        echo "Failed to identify remote CML: $output"
+        return $rc
     fi
-
-    if ! check_cml_versions ${VIRL_VERSION} ${output}; then
-        cleanup_from_host "${key_dir}"
-        echo "Migration between versions is not supported.  Source server version: ${output}, Dest server version: ${VIRL_VERSION}."
+    IFS='#' read -r is_connector virl_version hostname <<<"$output"
+    if check_cml_versions "$virl_version" && check_cml_is_connector "$is_connector"; then
+        echo "Preliminary checks pass."
+        ask_confirm "Do you want to continue transfer from host '$hostname' into '$HOSTNAME'?" "transfer"
+    else
         return 1
     fi
 
-    if [ ${DOING_MIGRATION} -eq 1 ]; then
-        (ssh -o "StrictHostKeyChecking=no" -i "${key_dir}"/${KEY_FILE} -p ${SSH_PORT} "${sysadmin_user}"@"${host}" "sudo /tmp/${ME} --mount-overlay") 2>/dev/null
-        if [ $? != 0 ]; then
-            rc=$?
-            cleanup_from_host "${key_dir}"
-            return ${rc}
-        fi
+    # Stop CML services on remote host.
+    ssh "${ssh_opts[@]}" "$host" "sudo chmod +x $OTHER_ME && sudo $OTHER_ME --stop" 2>/dev/null || rc=$?
+    if [[ $rc != 0 ]]; then
+        echo "Failed to stop source CML services."
+        return $rc
     fi
 
-    migr_arg=""
-    if [ ${DOING_MIGRATION} -eq 1 ]; then
-        migr_arg="--migration"
-    fi
-    # Build the list of remote src dirs.
-    output=$( (ssh -o "StrictHostKeyChecking=no" -i "${key_dir}"/${KEY_FILE} -p ${SSH_PORT} "${sysadmin_user}"@"${host}" "sudo /tmp/${ME} ${migr_arg} --src-dirs") 2>/dev/null)
-    if [ $? != 0 ]; then
-        rc=$?
-        cleanup_from_host "${key_dir}"
-        echo "Failed to obtain remote src dirs."
-        return ${rc}
-    fi
+    trap cleanup_failed_from_host SIGINT ERR
 
-    SRC_DIRS=${output}
-    delete_local_dirs "${SRC_DIRS}"
-
-    # Get the list of domains from virsh.
-    libvirt_domains=$( (ssh -o "StrictHostKeyChecking=no" -i "${key_dir}"/${KEY_FILE} -p ${SSH_PORT} "${sysadmin_user}"@"${host}" "sudo /tmp/${ME} --get-domains") 2>/dev/null)
-    if [ $? != 0 ]; then
-        rc=$?
-        cleanup_from_host "${key_dir}"
-        echo "Failed to get libvirt domains from ${host}: ${libvirt_domains}"
-        return ${rc}
+    # Capture the mktemp path the source host picked for the export.
+    output=$(ssh "${ssh_opts[@]}" "$host" "sudo $OTHER_ME --prepare-export") || rc=$?
+    if [[ $rc != 0 ]]; then
+        echo "Failed to prepare export on $host"
+        return $rc
     fi
-
-    # Get the list of networks from virsh
-    libvirt_networks=$( (ssh -o "StrictHostKeyChecking=no" -i "${key_dir}"/${KEY_FILE} -p ${SSH_PORT} "${sysadmin_user}"@"${host}" "sudo /tmp/${ME} --get-networks") 2>/dev/null)
-    if [ $? != 0 ]; then
-        rc=$?
-        cleanup_from_host "${key_dir}"
-        echo "Failed to get libvirt networks from ${host}: ${libvirt_networks}"
-        return ${rc}
+    REMOTE_WORK_DIR=$(grep -oE 'PREPARE_EXPORT_PATH=\S+' <<<"$output" | tail -1 | cut -d= -f2)
+    if [[ -z "$REMOTE_WORK_DIR" ]]; then
+        echo "Source host did not return a working-dir path; aborting."
+        return 1
     fi
-
-    # Get the list of ifaces from virsh
-    libvirt_ifaces=$( (ssh -o "StrictHostKeyChecking=no" -i "${key_dir}"/${KEY_FILE} -p ${SSH_PORT} "${sysadmin_user}"@"${host}" "sudo /tmp/${ME} --get-ifaces") 2>/dev/null)
-    if [ $? != 0 ]; then
-        rc=$?
-        cleanup_from_host "${key_dir}"
-        echo "Failed to get libvirt ifaces from ${host}: ${libvirt_ifaces}"
-        return ${rc}
-    fi
-
-    SRC_DIRS="${SRC_DIRS} ${libvirt_domains} ${libvirt_networks} ${libvirt_ifaces}"
-
-    echo "Migrating ${SRC_DIRS} to this CML server..."
-    space_dirs=""
-    if [ ${DOING_MIGRATION} -eq 1 ]; then
-        for map_dir in ${MIGRATION_MAP}; do
-            space_dirs="${space_dirs} $(echo "${map_dir}" | cut -d':' -f1)"
-        done
-    fi
+    SRC_DIRS+=("$REMOTE_WORK_DIR")
 
     # Get required disk space from remote host
-    output=$( (ssh -o "StrictHostKeyChecking=no" -i "${key_dir}"/${KEY_FILE} -p ${SSH_PORT} "${sysadmin_user}"@"${host}" "sudo du -B1 -sc ${SRC_DIRS} ${space_dirs} | grep total | sed -E -s 's|\s+total||'") 2>/dev/null)
-    if check_disk_space "" ${BASE_DIR} "${output}"; then
-        printf "Starting migration.  Please be patient, migration may take a while....\n\n\n"
-        sdirs=""
-        for src_dir in ${SRC_DIRS}; do
-            sdirs="${sdirs} ${sysadmin_user}"@"${scp_rsync_host}":"${src_dir}"
-        done
-        rsync -aAvzXR --progress --checksum --rsync-path="sudo rsync" --exclude="*.rej" --exclude="*.orig" -e "ssh -o StrictHostKeyChecking=no -i ${key_dir}/${KEY_FILE} -p ${SSH_PORT}" ${sdirs} /
-        #        output=$( (ssh -o "StrictHostKeyChecking=no" -i "${key_dir}"/${KEY_FILE} -p ${SSH_PORT} sysadmin@"${host}" "sudo tar --acls --selinux -cpf - ${SRC_DIRS}" | tar -C / --acls --selinux -xpf -) 2>&1 )
-        rc=$?
-        if [ ${rc} != 0 ]; then
-            echo "Migration completed with errors.  See the output above for details."
-        else
-            # Migrate each mapped src dir to its target dir.
-            success=1
-            if [ ${DOING_MIGRATION} -eq 1 ]; then
-                for map_dir in ${MIGRATION_MAP}; do
-                    src_dir=${sysadmin_user}@${scp_rsync_host}:$(echo "${map_dir}" | cut -d':' -f1)
-                    dest_dir=$(dirname $(echo "${map_dir}" | cut -d':' -f2))
-                    delete_local_dirs "$(echo "${map_dir}" | cut -d':' -f2)"
-                    rsync -aAvzX --progress --checksum --rsync-path="sudo rsync" --exclude="*.rej" --exclude="*.orig" -e "ssh -o StrictHostKeyChecking=no -i ${key_dir}/${KEY_FILE} -p ${SSH_PORT}" "${src_dir}" "${dest_dir}"
-                    rc=$?
-                    if [ ${rc} != 0 ]; then
-                        echo "Migration completed with errors.  See the output above for details."
-                        success=0
-                        break
-                    fi
-                done
-            fi
-            if [ ${success} = 1 ]; then
-                if [ ${DOING_MIGRATION} -eq 0 ]; then
-                    # For each of the libvirt domains, migrate the XML.
-                    echo "Migrating libvirt domains..."
-                    output=$(define_domains "${libvirt_domains}" 2>&1)
-                    rc=$?
-                    echo "Libvirt domain output is '${output}'"
-                    if [ ${rc} != 0 ]; then
-                        echo "Libvirt domain import completed with errors:"
-                        printf '%s\n\n' "${output}"
-                    else
-                        # For each of the libvirt networks, migrate the XML.
-                        echo "Migrating libvirt networks..."
-                        output=$(define_networks "${libvirt_networks}" 2>&1)
-                        rc=$?
-                        echo "Libvirt network output is '${output}'"
-                        if [ ${rc} != 0 ]; then
-                            echo "Libvirt network import completed with errors:"
-                            printf '%s\n\n' "${output}"
-                        else
-                            # For each of the libvirt ifaces, migrate the XML.
-                            echo "Migrating libvirt ifaces..."
-                            output=$(define_ifaces "${libvirt_ifaces}" 2>&1)
-                            rc=$?
-                            echo "Libvirt iface output is '${output}'"
-                            if [ ${rc} != 0 ]; then
-                                echo "Libvirt network import completed with errors:"
-                                printf '%s\n\n' "${output}"
-                            else
-                                echo "Migration completed SUCCESSFULLY."
-                                echo "Please make sure you have either mounted the same refplat ISO on or copied its contents to this CML server."
-                            fi
-                        fi
-                    fi
-                else
-                    printf "\nData transfer completed SUCCESSFULLY.\n"
-                    echo "Performing configuration migration..."
-                    output=$( (cd "${BASE_DIR}"/db_migrations && env CFG_DIR="${CFG_DIR}" BASE_DIR="${BASE_DIR}" VIRL2_DIR="${BASE_DIR}" HOME="${BASE_DIR}" MIGRATION_LIBVIRT_DOM_XML_DIR="${libvirt_domains}" MIGRATION_LIBVIRT_NET_XML_DIR="${libvirt_networks}" MIGRATION_LIBVIRT_IF_XML_DIR="${libvirt_ifaces}" COMPUTE_ID="${COMPUTE_ID}" MIGRATION=1 HOSTNAME="${HOSTNAME}" "${BASE_DIR}"/.local/bin/alembic upgrade head) 2>&1)
-                    rc=$?
-                    # This feels hacky, but we need to do it.
-                    chown -R www-data:www-data "${CFG_DIR}"
-                    find "${BASE_DIR}"/images -type f \( -name "*.img" -or -name "nodedisk*" \) -print0 | xargs -0 chown libvirt-qemu:kvm 2>/dev/null
-                    if [ ${rc} != 0 ]; then
-                        echo "Failed to execute data upgrade script:"
-                        printf '%s\n\n' "${output}"
-                    else
-                        echo "Migration completed SUCCESSFULLY."
-                    fi
-                fi
-            fi
-        fi
-    else
-        rc=$?
+    output=$(ssh "${ssh_opts[@]}" "$host" "sudo du -B1 -sc ${SRC_DIRS[*]} | sed -n -E -e 's|\s+total||p'" 2>/dev/null) || rc=$?
+    if [[ $rc != 0 ]]; then
+        echo "Failed to determine migrated data size requirement on source host"
+        return $rc
     fi
 
-    printf "\nFinishing up with the remote host..."
-    if [ ${DOING_MIGRATION} -eq 1 ]; then
-        ssh -o "StrictHostKeyChecking=no" -i "${key_dir}"/${KEY_FILE} -p ${SSH_PORT} "${sysadmin_user}"@"${host}" "sudo /tmp/${ME} --umount-overlay"
+    echo "Preparing this host..."
+    prepare_local || rc=$?
+    if [[ $rc != 0 ]]; then
+        echo "Failed to prepare before syncing"
+        return $rc
     fi
 
-    if ! ssh -o "StrictHostKeyChecking=no" -i "${key_dir}"/${KEY_FILE} -p ${SSH_PORT} "${sysadmin_user}"@"${host}" "sudo /tmp/${ME} --start && sudo rm -rf ${libvirt_domains} && sudo rm -rf ${libvirt_networks} && sudo rm -rf ${libvirt_ifaces} && sudo rm -f /tmp/${ME} && sudo rm -f /etc/sudoers.d/cml-migrate && (cp -fa ~/.ssh/authorized_keys.migration ~/.ssh/authorized_keys >/dev/null 2>&1 || true)"; then
-        printf "FAILED.\n"
-        echo "Error finishing up on remote host.  Check to make sure the CML services are running on ${host}."
-        rc=$?
-    else
-        printf "DONE.\n"
+    if ! check_disk_space "$BASE_DIR" "$output"; then
+        return 1
     fi
 
-    rm -rf "${key_dir}"
-    rm -rf "${libvirt_domains}"
-    rm -rf "${libvirt_networks}"
-    rm -rf "${libvirt_ifaces}"
+    printf "Starting migration.  Please be patient, migration may take a while....\n\n\n"
+    rsync_opts=("-aAvzXR" "--progress" "--checksum" "--rsync-path=sudo rsync" "-e" "ssh ${ssh_opts[*]}")
+    rsync "${rsync_opts[@]}" "${EXCLUDES[@]}" "${SRC_DIRS[@]/#/$scp_rsync_host:}" / || rc=$?
+    if [[ $rc != 0 ]]; then
+        echo "Migration completed with errors.  See the output above for details."
+        return $rc
+    fi
+    printf "\nData transfer completed SUCCESSFULLY.\n"
+    perform_restore
 
+    trap - SIGINT ERR
     restart_cml_services
-
-    return ${rc}
+    printf "\nFinishing up with the remote host...\n"
+    cleanup_remote_from_host
+    printf "DONE.\n"
+    return $rc
 }
 
-ME=$(basename "$0")
-LOCAL_ME=$0
 set_virl_version
 
-if [ "$EUID" != 0 ]; then
+if [[ "$EUID" != 0 ]]; then
     echo "This script must be run as root.  Use 'sudo' to run it."
     exit 1
 fi
 
-opts=$(getopt -o brf:h:vdu: --long host:,file:,backup,restore,cml-version,src-dirs,stop,start,get-domains,get-networks,get-ifaces,mount-overlay,umount-overlay,migration,no-confirm,user,version,update -- "$@")
-if [ $? != 0 ]; then
-    echo "usage: $0 -h|--host HOST_TO_MIGRATE_FROM"
+if ! opts=$(getopt -o brf:h:vu: --long host:,file:,backup,restore,cml-identify,stop,start,prepare-export,no-confirm,user:,port:,version,update -- "$@"); then
+    echo "usage: $0 -h|--host HOST_TO_MIGRATE_FROM [-p|--port SSH_PORT=$SSH_PORT] [-u|--user USER=$DEFAULT_USER]"
+
     echo "       OR"
     echo "       $0 -b|--backup|-r|--restore -f|--file PATH_TO_BACKUP_FILE"
     exit 1
@@ -865,321 +718,238 @@ fi
 
 REMOTE_HOST=
 BACKUP_FILE=
-BACKUP=0
-RESTORE=0
-GET_SRC_DIRS=0
-NO_CONFIRM=0
+BACKUP=false
+RESTORE=false
+NO_CONFIRM=false
 
-sysadmin_user=${DEFAULT_USER}
+sysadmin_user=$DEFAULT_USER
+ssh_port=$SSH_PORT
+WORKING_DIR=
 
 eval set -- "$opts"
 while true; do
     case "$1" in
-    -h | --host)
-        shift
-        REMOTE_HOST=$1
-        ;;
-    -f | --file)
-        shift
-        BACKUP_FILE=$1
-        ;;
-    -b | --backup)
-        BACKUP=1
-        ;;
-    -m | --migration)
-        DOING_MIGRATION=1
-        ;;
-    -r | --restore)
-        RESTORE=1
-        ;;
-    --cml-version)
-        echo ${VIRL_VERSION}
-        exit 0
-        ;;
-    -u | --user)
-        shift
-        sysadmin_user=$1
-        ;;
-    -d | --src-dirs)
-        GET_SRC_DIRS=1
-        ;;
-    --stop)
-        stop_cml_services
-        exit $?
-        ;;
-    --start)
-        restart_cml_services
-        exit $?
-        ;;
-    --get-domains)
-        export_libvirt_domains
-        exit $?
-        ;;
-    --get-networks)
-        export_libvirt_networks
-        exit $?
-        ;;
-    --get-ifaces)
-        export_libvirt_ifaces
-        exit $?
-        ;;
-    --mount-overlay)
-        mount_refplat_overlay
-        exit $?
-        ;;
-    --umount-overlay)
-        umount_refplat_overlay
-        exit $?
-        ;;
-    --no-confirm)
-        NO_CONFIRM=1
-        ;;
-    -v | --version)
-        echo "${_VERSION}"
-        exit 0
-        ;;
-    --update)
-        check_for_updates
-        exit $?
-        ;;
-    --)
-        shift
-        break
-        ;;
+        -h | --host)
+            shift
+            REMOTE_HOST=$1
+            ;;
+        -f | --file)
+            shift
+            BACKUP_FILE=$1
+            ;;
+        -b | --backup)
+            BACKUP=true
+            ;;
+        -r | --restore)
+            RESTORE=true
+            ;;
+        --cml-identify)
+            echo "$IS_CONNECTOR#$VIRL_VERSION#$HOSTNAME"
+            exit 0
+            ;;
+        -p | --port)
+            shift
+            ssh_port=$1
+            ;;
+        -u | --user)
+            shift
+            sysadmin_user=$1
+            ;;
+        --stop)
+            if check_cml_versions; then
+                stop_cml_services
+            fi
+            exit $?
+            ;;
+        --start)
+            if check_cml_versions; then
+                restart_cml_services
+            fi
+            exit $?
+            ;;
+        --prepare-export)
+            # Runs on the source host; the initiator captures the path.
+            WORKING_DIR=$(mktemp -d /var/tmp/migration.XXXXX)
+            prep_rc=0
+            if check_cml_versions; then
+                prepare_export || prep_rc=$?
+            else
+                prep_rc=$?
+            fi
+            if [[ $prep_rc != 0 ]]; then
+                rm -rf "$WORKING_DIR"
+                exit "$prep_rc"
+            fi
+            echo "PREPARE_EXPORT_PATH=$WORKING_DIR"
+            exit "$prep_rc"
+            ;;
+        --no-confirm)
+            NO_CONFIRM=true
+            ;;
+        -v | --version)
+            echo "$_VERSION"
+            exit 0
+            ;;
+        --update)
+            check_for_updates
+            exit $?
+            ;;
+        --)
+            shift
+            break
+            ;;
     esac
     shift
 done
 
-if [ ${GET_SRC_DIRS} -eq 1 ]; then
-    build_local_src_dirs
-    echo ${SRC_DIRS}
-    exit 0
-fi
-
-if [ -n "${REMOTE_HOST}" ] && [ -n "${BACKUP_FILE}" ]; then
+if [[ -n "$REMOTE_HOST" && -n "$BACKUP_FILE" ]]; then
     echo "Only one of --host or --file may be specified."
     exit 1
 fi
 
-if [ -z "${REMOTE_HOST}" ] && [ -z "${BACKUP_FILE}" ]; then
+if [[ -z "$REMOTE_HOST" && -z "$BACKUP_FILE" ]]; then
     echo "One of --host or --file must be specified."
     exit 1
 fi
 
-if [ -n "${REMOTE_HOST}" ]; then
-    sync_from_host "${REMOTE_HOST}"
-    exit $?
+if [[ -z "$WORKING_DIR" ]]; then
+    WORKING_DIR=$(mktemp -d /var/tmp/migration.XXXXX)
 fi
 
-if [ ${BACKUP} = 1 ] && [ ${RESTORE} = 1 ]; then
-    echo "Only one of --backup or --restore can be specified."
+rc=0
+if [[ -n "$REMOTE_HOST" ]]; then
+    sync_from_host "$REMOTE_HOST" || rc=$?
+    cleanup_local
+    exit $rc
+fi
+
+if [[ "$BACKUP" == "$RESTORE" ]]; then
+    echo "Exactly one of --backup or --restore must be specified."
     exit 1
 fi
 
-if [ ${BACKUP} = 0 ] && [ ${RESTORE} = 0 ]; then
-    echo "One of --backup or --restore must be specified."
-    exit 1
-fi
-
-if [ ${RESTORE} = 1 ]; then
-    if [ ! -f "${BACKUP_FILE}" ]; then
-        echo "Backup file ${BACKUP_FILE} does not exist or is not a file."
+if $RESTORE; then
+    if [[ ! -f "$BACKUP_FILE" ]]; then
+        echo "Backup file $BACKUP_FILE does not exist or is not a file."
         exit 1
     fi
-
-    DOING_MIGRATION=0
 
     # While not all data may go to the product root, the way CML's file system
     # is laid out means it's almost certainly going to be on the same FS.
-    if ! check_disk_space "${BACKUP_FILE}" ${BASE_DIR}; then
-        exit $?
-    fi
-
-    if [ ${NO_CONFIRM} -eq 0 ]; then
-        read -r -p "Do you wish to restore from ${BACKUP_FILE}?  This will overwrite current local data. [y/N] " confirm
-        echo
-        if echo "${confirm}" | grep -qiv '^y'; then
-            echo "Terminating restore."
-            exit 0
-        fi
-    fi
-
-    # First, extract /PRODUCT from the backup and check that the version matches the current version.
-    tempd=$(mktemp -d /tmp/migration.XXXXX)
-    output=$(tar -C "${tempd}" --acls --selinux -xpf "${BACKUP_FILE}" PRODUCT libvirt_domains.dat libvirt_networks.dat libvirt_ifaces.dat 2>&1)
-    rc=$?
-    if [ ${rc} != 0 ]; then
-        echo "Failed to extract /PRODUCT and libvirt data from backup:"
-        printf '%s\n\n' "${output}"
-        exit ${rc}
-    fi
-
-    virl_version=$(set_virl_version "${tempd}"/PRODUCT)
-    # This will set DOING_MIGRATION if needed.
-    if ! check_cml_versions ${VIRL_VERSION} "${virl_version}"; then
-        rm -rf "${tempd}"
-        echo "Versions do not match or migration path not supported.  Source server version: ${virl_version}, Dest server version: ${VIRL_VERSION}."
+    if ! check_disk_space "$BASE_DIR" "$DU" "$BACKUP_FILE"; then
         exit 1
     fi
 
-    ddir=$(cat "${tempd}"/libvirt_domains.dat)
-    ndir=$(cat "${tempd}"/libvirt_networks.dat)
-    idir=$(cat "${tempd}"/libvirt_ifaces.dat)
+    ask_confirm "Do you wish to restore from $BACKUP_FILE?  This will replace current local data" "restore"
 
-    rm -rf "${tempd}"
-
-    stop_cml_services || (
-        echo "Failed to stop CML services."
-        exit $?
-    )
-    delete_libvirt_domains
-    delete_libvirt_networks
-    delete_libvirt_ifaces
-
-    trap cleanup_failed_restore SIGINT
-
-    echo "Restoring ${BACKUP_FILE} to local CML.  Please be patient, this may take a while..."
-    sdirs=""
-    if [ ${DOING_MIGRATION} -eq 1 ]; then
-        for sdir in ${SRC_DIRS}; do
-            # Remove the leading '/' to match what's in the tar file.
-            sdirs="${sdirs} $(echo "${sdir}" | cut -d'/' -f2-)"
-        done
-        # Add the directory that contains the libvirt domains.
-        sdirs="${sdirs} $(echo "${ddir}" | cut -d'/' -f2-)"
-        # Add the directory that contains the libvirt networks.
-        sdirs="${sdirs} $(echo "${ndir}" | cut -d'/' -f2-)"
-        # Add the directory that contains the libvirt ifaces.
-        sdirs="${sdirs} $(echo "${idir}" | cut -d'/' -f2-)"
-        echo "Extracting ${sdirs} from the backup..."
+    # First, extract /PRODUCT from the backup and check that the version matches the current version.
+    echo "Checking source archive..."
+    mkdir -p "$WORKING_DIR"
+    output=$(
+        tar -C "$WORKING_DIR" --occurrence=1 --acls --selinux \
+            --transform="s|^MIGRATION/||" -xpf "$BACKUP_FILE" PRODUCT "MIGRATION/$CFG_FILE" 2>&1
+    ) || rc=$?
+    if [[ $rc != 0 ]]; then
+        echo "Failed to extract metadata from backup:"
+        printf '%s\n\n' "$output"
+        exit $rc
     fi
 
-    delete_local_dirs "$(tar -tf "${BACKUP_FILE}" | grep '/$')" "/" 0
-    export total=$(du -shc ${BACKUP_FILE} -B10k --apparent-size | tail -1 | cut -f1)
-    tar -C / --acls --selinux --checkpoint=2000 --checkpoint-action=exec=' printf "\e[1;31m%s of %s extracted  %d/100%% complete  \e[0m\r" $(numfmt --to=iec-i $((10000*${TAR_CHECKPOINT})) ) $(numfmt --to=iec-i $((10000*${total})) )\t$((100*${TAR_CHECKPOINT}/${total})) ' --exclude=PRODUCT --exclude="libvirt*.dat" -xvpf "${BACKUP_FILE}"
-    rc=$?
-    if [ ${rc} != 0 ]; then
-        echo "Restore failed with error.  See output above for the error details."
+    virl_version=$(set_virl_version "$WORKING_DIR/PRODUCT")
+    is_connector=$(sed -n -e '/^IS_CONNECTOR/{s/[^01]//gp;q}' "$WORKING_DIR/$CFG_FILE")
+    if check_cml_versions "$virl_version" && check_cml_is_connector "$is_connector"; then
+        echo "Preliminary checks pass."
     else
-        if [ ${DOING_MIGRATION} -eq 1 ]; then
-            printf "\nRestore completed SUCCESSFULLY.\n"
-            echo "Performing configuration migration..."
-            output=$( (cd "${BASE_DIR}"/db_migrations && env CFG_DIR="${CFG_DIR}" BASE_DIR="${BASE_DIR}" VIRL2_DIR="${BASE_DIR}" HOME="${BASE_DIR}" MIGRATION_LIBVIRT_DOM_XML_DIR="${ddir}" MIGRATION_LIBVIRT_NET_XML_DIR="${ndir}" MIGRATION_LIBVIRT_IF_XML_DIR="${idir}" COMPUTE_ID="${COMPUTE_ID}" MIGRATION=1 HOSTNAME="${HOSTNAME}" "${BASE_DIR}"/.local/bin/alembic upgrade head) 2>&1)
-            rc=$?
-            # This feels hacky, but we need to do it.
-            chown -R www-data:www-data "${CFG_DIR}"
-            find "${BASE_DIR}"/images -type f \( -name "*.img" -or -name "nodedisk*" \) -print0 | xargs -0 chown libvirt-qemu:kvm 2>/dev/null
-            if [ ${rc} != 0 ]; then
-                echo "Failed to execute data upgrade script:"
-                printf '%s\n\n' "${output}"
-            else
-                echo "Migration completed SUCCESSFULLY."
-            fi
-        else
-            output=$(define_domains "${ddir}" 2>&1)
-            rc=$?
-            if [ ${rc} != 0 ]; then
-                echo "Libvirt domain import completed with errors:"
-                printf '%s\n\n' "${output}"
-            else
-                output=$(define_networks "${ndir}" 2>&1)
-                rc=$?
-                if [ ${rc} != 0 ]; then
-                    echo "Libvirt network import completed with errors:"
-                    printf '%s\n\n' "${output}"
-                else
-                    output=$(define_ifaces "${idir}" 2>&1)
-                    rc=$?
-                    if [ ${rc} != 0 ]; then
-                        echo "Libvirt iface import completed with errors:"
-                        printf '%s\n\n' "${output}"
-                    else
-                        echo "Restore completed SUCCESSFULLY."
-                        echo "Please make sure you have either mounted the same refplat ISO on or copied its contents to this CML server."
-                    fi
-                fi
-            fi
-        fi
+        cleanup_local
+        exit 1
     fi
 
-    rm -rf "${ddir}"
-    rm -rf "${ndir}"
-    rm -rf "${idir}"
+    echo "Preparing this host..."
+    prepare_local || rc=$?
+    if [[ $rc != 0 ]]; then
+        echo "Failed to prepare before extraction"
+        exit $rc
+    fi
+    find "${SRC_DIRS[@]}" -xdev -mindepth 1 "!" -name "$IOL_RUNNER" -delete || rc=$?
+    if [[ $rc != 0 ]]; then
+        echo "Failed to clean up local directories."
+    fi
+    mkdir -p "$IMG_DIR/at"
+    chown virl2:virl2 "$IMG_DIR/at"
 
+    trap cleanup_failed_restore SIGINT ERR
+
+    echo "Extracting $BACKUP_FILE to local CML.  Please be patient, this may take a while..."
+    total=$(du -shc "$BACKUP_FILE" -B10k --apparent-size | tail -1 | cut -f1)
+    export total
+
+    tar -C / --overwrite --acls --selinux --exclude=PRODUCT \
+        --checkpoint=2000 --checkpoint-action=exec="$tar_checkpoint_action" \
+        --transform="s|^MIGRATION|${WORKING_DIR#/}|" -xvpf "$BACKUP_FILE" || rc=$?
+    if [[ $rc != 0 ]]; then
+        echo "Extraction failed with error.  See output above for the error details."
+    else
+        echo -e "\nExtraction completed SUCCESSFULLY.\n"
+        perform_restore
+    fi
+
+    trap - SIGINT ERR
     restart_cml_services
+    cleanup_local
 
-    exit ${rc}
+    exit $rc
 fi
 
-if [ ${DOING_MIGRATION} -eq 0 ]; then
-    build_local_src_dirs
-else
-    for mig_dir in ${MIGRATION_MAP}; do
-        SRC_DIRS="${SRC_DIRS} $(echo "${mig_dir}" | cut -d':' -f1)"
-    done
-fi
+# Doing Backup
 
-BACKUP_FILE=$(realpath "${BACKUP_FILE}")
+BACKUP_FILE=$(realpath "$BACKUP_FILE")
+
+if [[ -e "$BACKUP_FILE" ]]; then
+    echo "The backup file $BACKUP_FILE already exists. Please remove it or use another filename."
+    exit 1
+fi
 
 # We are doing a dump to a single tar file.
-if ! check_disk_space "${SRC_DIRS}" "$(dirname "${BACKUP_FILE}")"; then
-    exit $?
+if ! check_disk_space "$(dirname "$BACKUP_FILE")" "$DU" "${SRC_DIRS[@]}"; then
+    exit 1
+fi
+# Check if we can back this up
+if ! check_cml_versions; then
+    exit 1
 fi
 
-if [ ${NO_CONFIRM} -eq 0 ]; then
-    read -r -p "Are you sure you want to backup?  Doing so will restart the CML services. [y/N] " confirm
-    echo
-    if echo "${confirm}" | grep -qiv '^y'; then
-        echo "Terminating backup."
-        exit 0
-    fi
-fi
+ask_confirm "Are you sure you want to backup to $BACKUP_FILE?  This will restart CML services" "backup"
 
 # Before stopping the services, fetch the diagnostics and put it in a folder to include in the backup.
-/usr/bin/curl -sk ip6-localhost:8001/api/internal/diagnostics > $CFG_DIR/diagnostics-$TIMESTAMP.log
-
-stop_cml_services || (
-    echo "Failed to stop CML services."
-    exit $?
-)
-
-trap cleanup_backup SIGINT
-
-if [ ${DOING_MIGRATION} -eq 1 ]; then
-    mount_refplat_overlay
-    if [ $? != 0 ]; then
-        exit $?
-    fi
+if [[ "$IS_CONNECTOR" == 1 ]]; then
+    /usr/bin/curl -sk ip6-localhost:8001/api/internal/diagnostics >"$CFG_DIR/diagnostics-$TIMESTAMP.log" || true
 fi
 
-ddir=$(export_libvirt_domains)
-ndir=$(export_libvirt_networks)
-idir=$(export_libvirt_ifaces)
-tempd=$(mktemp -d /tmp/migration.XXXXX)
-cd "${tempd}" || (
-    echo "Failed to cd to ${tempd}"
-    exit $?
-)
-echo "${ddir}" >libvirt_domains.dat
-echo "${ndir}" >libvirt_networks.dat
-echo "${idir}" >libvirt_ifaces.dat
+rc=0
+stop_cml_services || rc=$?
+if [[ $rc != 0 ]]; then
+    echo "Failed to stop CML services."
+    exit $rc
+fi
 
-# Try to preserve some info about the server's network configuration.
-export_network_configuration
+trap cleanup_backup SIGINT ERR
 
-SRC_DIRS="${SRC_DIRS} ${ddir} ${ndir} ${idir}"
+prepare_export
+SRC_DIRS+=("$WORKING_DIR")
 
-echo "Backing up ${SRC_DIRS}..."
+echo "Backing up CML data to $BACKUP_FILE.  Please be patient, this may take a while..."
+total=$(du -shc /PRODUCT "${SRC_DIRS[@]}" -B10k --apparent-size | tail -1 | cut -f1)
+export total
 
-echo "Backing up CML data to ${BACKUP_FILE}.  Please be patient, this may take a while..."
-export total=$(du -shc /PRODUCT ${SRC_DIRS} libvirt_domains.dat libvirt_networks.dat libvirt_ifaces.dat -B10k --apparent-size | tail -1 | cut -f1)
-tar -C "${tempd}" --acls --selinux --checkpoint=2000 --exclude="*.rej" --exclude="*.orig" --checkpoint-action=exec=' printf "\e[1;31m%s of %s copied  %d/100%% complete  \e[0m\r" $(numfmt --to=iec-i $((10000*${TAR_CHECKPOINT})) ) $(numfmt --to=iec-i $((10000*${total})) )\t$((100*${TAR_CHECKPOINT}/${total})) ' -cvpf "${BACKUP_FILE}" /PRODUCT libvirt_domains.dat libvirt_networks.dat libvirt_ifaces.dat ${SRC_DIRS}
-rc=$?
-echo
-if [ ${rc} != 0 ]; then
+tar -C "$WORKING_DIR" --acls --selinux "${EXCLUDES[@]}" \
+    --checkpoint=2000 --checkpoint-action=exec="$tar_checkpoint_action" \
+    --transform="s|^${WORKING_DIR#/}|MIGRATION|" -cvpf "$BACKUP_FILE" /PRODUCT "${SRC_DIRS[@]}" || rc=$?
+if [[ $rc != 0 ]]; then
+    echo
     echo "Backup completed with errors.  See the output above for the error details."
 else
-    echo "Backup completed SUCCESSFULLY.  Backup file is ${BACKUP_FILE}."
+    echo
+    echo "Backup completed SUCCESSFULLY.  Backup file is $BACKUP_FILE."
 fi
 
 cleanup_backup


### PR DESCRIPTION
Sync the migration tool with the version shipped in CML 2.10.0 (simple repo, release/v2.10.0).  The new script supports source hosts running CML 2.6.x-2.10.x and targets running 2.8.x-2.10.x, auto-detects version migrations (the --migration flag is gone), and adds --port and --no-confirm options.

Update the README to reflect the supported version range, drop the obsolete CentOS->Ubuntu (2.2->2.3) migration note and the removed --migration flag, and document the new --port / --no-confirm flags.